### PR TITLE
Redesign correspondence API

### DIFF
--- a/rrn.py
+++ b/rrn.py
@@ -12,7 +12,8 @@ HYPHEN = re.compile('[-–]')
 BIRTH = 0, 6
 MONTH_OF_BIRTH = 0, 4
 MONTH_OF_BIRTH_FORMAT = '%y%m'
-DAY_OF_BIRTH_FORMAT = '%y%m%d'
+DAY_OF_BIRTH_LITERAL_FORMAT = '%y%m%d'
+DAY_OF_BIRTH_DATE_FORMAT = '%Y%m%d'
 
 SEX = 6
 
@@ -37,7 +38,7 @@ def _validate_day_of_birth(rrn: str) -> bool:
     try:
         return datetime.strptime(
             rrn[slice(*BIRTH)].ljust(BIRTH[1], '0'),
-            DAY_OF_BIRTH_FORMAT
+            DAY_OF_BIRTH_LITERAL_FORMAT
         ) is not None if len(rrn) >= 5 else True
     except ValueError:
         return False
@@ -93,8 +94,11 @@ def is_valid_rrn(rrn: str) -> bool:
 def _is_birthday_corresponding(rrn: str, birthday: date) -> Optional[bool]:
     try:
         return datetime.strptime(
-            rrn[slice(*BIRTH)],
-            DAY_OF_BIRTH_FORMAT
+            '{century}{rrn}'.format(
+                century=birthday.year // 100,
+                rrn=rrn[slice(*BIRTH)]
+            ),
+            DAY_OF_BIRTH_DATE_FORMAT
         ).date() == birthday
     except (TypeError, ValueError):
         return None

--- a/rrn.py
+++ b/rrn.py
@@ -124,31 +124,28 @@ def is_corresponding_rrn(
     birthday: Optional[date]=None,
     foreign: Optional[bool]=None,
     female: Optional[bool]=None
-) -> Optional[bool]:
+) -> bool:
     """
     Check given RRN if it corresponds with given information or not.
-    It returns None if correspondence is undecidable.
-    For example, 6-digit RRN string does not contain any information about sex.
+    It returns True still if correspondence is undecidable. (ex. 6-digit RRN
+    literal does not contain any information about sex)
 
     :param rrn: RRN string
     :param birthday: expected date of birth
     :param foreign: expected to be foreigner or not
     :param female: expected to be female or not
-    :return: correspondence (None if it's undecidable)
+    :return: correspondence
     """
     try:
         rrn = HYPHEN.sub('', rrn)
         assert rrn.isdigit()
-        return (
-            (
-                birthday is None or _is_birthday_corresponding(rrn, birthday)
-            ) and
-            (
-                foreign is None or _is_foreignness_corresponding(rrn, foreign)
-            ) and
-            (
-                female is None or _is_sex_corresponding(rrn, female)
-            )
+
+        parts = (
+            birthday is None or _is_birthday_corresponding(rrn, birthday),
+            foreign is None or _is_foreignness_corresponding(rrn, foreign),
+            female is None or _is_sex_corresponding(rrn, female)
         )
+
+        return all(p is None or p for p in parts)
     except (AssertionError, TypeError):
-        return None
+        return False

--- a/tests/test_rrn.py
+++ b/tests/test_rrn.py
@@ -43,16 +43,16 @@ class TestRRN(unittest.TestCase):
             self.assertEqual(expected, rrn.is_valid_rrn(s))
 
     def test_is_corresponding_rrn(self):
-        undecided, corresponding, not_corresponding = None, True, False
+        corresponding, not_corresponding = True, False
         female, male = True, False
         foreign, domestic = True, False
 
         for r, (b, s, f), expected in [
-            ('RRN', (None, None, None), undecided),
+            ('RRN', (None, None, None), not_corresponding),
             ('940812', (None, None, None), corresponding),
-            ('940812', (None, male, None), undecided),
-            ('940812', (None, None, foreign), undecided),
-            ('940812', (None, female, foreign), undecided),
+            ('940812', (None, male, None), corresponding),
+            ('940812', (None, None, foreign), corresponding),
+            ('940812', (None, female, foreign), corresponding),
             ('8808121', (None, male, domestic), corresponding),
             ('6008122', (None, None, foreign), not_corresponding),
             ('7403225', (None, female, None), not_corresponding),
@@ -61,7 +61,9 @@ class TestRRN(unittest.TestCase):
             ('0408127', (date(2004, 8, 12), male, domestic), not_corresponding),
             ('9408122', (date(1994, 8, 12), female, domestic), corresponding),
             ('9802145', (date(1998, 2, 14), male, foreign), corresponding),
-            ('9103226', (date(1991, 3, 22), female, foreign), corresponding)
+            ('9103226', (date(1991, 3, 22), female, foreign), corresponding),
+            ('620904', (date(1962, 9, 4), male, domestic), corresponding),
+            ('6209041', (date(1962, 9, 4), male, domestic), corresponding)
         ]:
             self.assertEqual(
                 expected,


### PR DESCRIPTION
- 2000년대, 1900년대를 구분하지 않아 생기는 문제를 해결했습니다.
- 주어진 정보만으로 주민등록번호 상응 여부를 알 수 없을 때 `None`이 아닌 `True`를 반환하도록 API 디자인을 변경했습니다. (비결정 여부는 이후 strict 버전의 함수를 통해 지원하는 형태로 변경하는 게 좋을 것 같아요)