### PR TITLE
외국인등록번호 유효성 검사 개선

### DIFF
--- a/rrn.py
+++ b/rrn.py
@@ -70,6 +70,22 @@ def _validate_hash(rrn: str) -> bool:
         return True
 
 
+def _is_valid_domestic_rrn(rrn: str) -> bool:
+    return (
+        rrn.isdigit() and
+        _validate_birth(rrn) and
+        _validate_location(rrn) and
+        _validate_hash(rrn)
+    )
+
+
+def _is_valid_foreign_rrn(rrn: str) -> bool:
+    return (
+        rrn.isdigit() and
+        _validate_birth(rrn)
+    )
+
+
 def is_valid_rrn(rrn: str) -> bool:
     """
     Validate given RRN and returns if it might be valid or not.
@@ -81,12 +97,10 @@ def is_valid_rrn(rrn: str) -> bool:
     """
     try:
         rrn = HYPHEN.sub('', rrn)
-        return (
-            rrn.isdigit() and
-            _validate_birth(rrn) and
-            _validate_location(rrn) and
-            _validate_hash(rrn)
-        )
+        if is_foreign(rrn):
+            return _is_valid_foreign_rrn(rrn)
+        else:
+            return _is_valid_domestic_rrn(rrn)
     except TypeError:
         return False
 

--- a/rrn.py
+++ b/rrn.py
@@ -81,9 +81,6 @@ def _is_valid_domestic_rrn(rrn: str) -> bool:
 
 def _is_valid_foreign_rrn(rrn: str) -> bool:
     return rrn.isdigit() and _validate_birth(rrn)
-        rrn.isdigit() and
-        _validate_birth(rrn)
-    )
 
 
 def is_valid_rrn(rrn: str) -> bool:

--- a/rrn.py
+++ b/rrn.py
@@ -156,7 +156,7 @@ def is_corresponding_rrn(
     It returns True still if correspondence is undecidable. (ex. 6-digit RRN
     literal does not contain any information about sex)
 
-    :param rrn: RRN string
+    :param rrn: RRN literal
     :param birthday: expected date of birth
     :param foreign: expected to be foreigner or not
     :param female: expected to be female or not

--- a/rrn.py
+++ b/rrn.py
@@ -80,7 +80,7 @@ def _is_valid_domestic_rrn(rrn: str) -> bool:
 
 
 def _is_valid_foreign_rrn(rrn: str) -> bool:
-    return (
+    return rrn.isdigit() and _validate_birth(rrn)
         rrn.isdigit() and
         _validate_birth(rrn)
     )

--- a/rrn.py
+++ b/rrn.py
@@ -112,8 +112,20 @@ def _is_sex_corresponding(rrn: str, female: bool) -> Optional[bool]:
 
 
 def _is_foreignness_corresponding(rrn: str, foreign: bool) -> Optional[bool]:
+    f = is_foreign(rrn)
+    return f == foreign if f is not None else None
+
+
+def is_foreign(rrn: str) -> Optional[bool]:
+    """
+    Check if given RRN literal is foreigner or not.
+    It returns None when given RRN literal is too short to determine.
+
+    :param rrn: RRN literal
+    :return: expectation to be foreigner or not
+    """
     try:
-        return (5 <= int(rrn[SEX]) <= 8) == foreign
+        return 5 <= int(rrn[SEX]) <= 8
     except IndexError:
         return None
 

--- a/tests/test_rrn.py
+++ b/tests/test_rrn.py
@@ -72,7 +72,11 @@ class TestRRN(unittest.TestCase):
             ('9408121001751', valid),
             ('9408121001750', invalid),
             ('9408221001740', valid),
-            ('9408221001741', invalid)
+            ('9408221001741', invalid),
+            ('9408225', valid),
+            ('940822699', valid),
+            ('940822700888', valid),
+            ('9408228008889', valid)
         ]:
             self.assertEqual(expected, rrn.is_valid_rrn(s))
 

--- a/tests/test_rrn.py
+++ b/tests/test_rrn.py
@@ -6,6 +6,40 @@ import rrn
 
 class TestRRN(unittest.TestCase):
 
+    def test_is_foreign(self):
+        undetermined = None
+        foreign, domestic = True, False
+        for s, expected in [
+            ('', undetermined),
+            ('9', undetermined),
+            ('94', undetermined),
+            ('940', undetermined),
+            ('9408', undetermined),
+            ('94081', undetermined),
+            ('940812', undetermined),
+            ('9408120', domestic),
+            ('94081201', domestic),
+            ('9408121', domestic),
+            ('94081212', domestic),
+            ('9408122', domestic),
+            ('94081223', domestic),
+            ('9408123', domestic),
+            ('94081234', domestic),
+            ('9408124', domestic),
+            ('94081245', domestic),
+            ('9408125', foreign),
+            ('94081256', foreign),
+            ('9408126', foreign),
+            ('94081267', foreign),
+            ('9408127', foreign),
+            ('94081278', foreign),
+            ('9408128', foreign),
+            ('94081289', foreign),
+            ('9408129', domestic),
+            ('94081290', domestic)
+        ]:
+            self.assertEqual(expected, rrn.is_foreign(s))
+
     def test_is_valid_rrn(self):
         valid, invalid = True, False
         for s, expected in [


### PR DESCRIPTION
1. 외국인등록번호의 경우 내국인 주민등록번호와 유효성 검사하는 방식이 다르고, 그 기준이 명확치 않기 때문에 **지역코드 검사 및 마지막 hash 값 검사를 수행하지 않도록** 처리했습니다. 
1. 외국인등록번호의 마지막 자리 처리 공식이 `[13 - {(2*A + 3*B + 4*C + 5*D + 6*E + 7*F + 8*G + 9*H + 2*I + 3*J + 4*K + 5*L) mod 11}] mod 10` 라는 비공식 글도 봤는데, 실제 지인의 외국인등록번호를 조사해본 결과 일치하지 않는 경우가 있는 것을 확인했습니다.